### PR TITLE
Avoid printing NumberFormatException stacktrace to prevent players from spamming the server logs

### DIFF
--- a/src/main/java/eu/pb4/universalshops/gui/setup/VirtualBalanceValueGui.java
+++ b/src/main/java/eu/pb4/universalshops/gui/setup/VirtualBalanceValueGui.java
@@ -43,7 +43,7 @@ public class VirtualBalanceValueGui extends AnvilInputGui implements ShopGui {
             }
             this.valid = true;
         } catch (Throwable e) {
-            e.printStackTrace();
+            if (!(e isntanceof NumberFormatException)) e.printStackTrace();
 
             if (this.valid) {
                 this.setTitle(TextUtil.gui("virtual_balance.cost.invalid_input").formatted(Formatting.RED));


### PR DESCRIPTION
Adds an if to prevent printing NumberFormatException stacktrace on VirtualBalanceValueGui as it isn't needed, as it is expected for invalid inputs, and prevents spamming of the server console/logs